### PR TITLE
Displays multiple hosts when there are more than one per line

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@ fs.readFile(HOSTS_FILE, 'utf8', (err, data) => {
       let parsedLine = line.trim().split(/\s+/);
       const isDisabled = parsedLine[0] === '#';
       const ip = parsedLine[isDisabled ? 1 : 0];
-      const host = parsedLine[isDisabled ? 2 : 1];
+      const host = parsedLine.slice(isDisabled ? 2 : 1);
       if (ip && host) {
         hosts.push({
           index: i,
           ip: ip,
-          host: host,
+          host: host.join(' '),
           disabled: isDisabled,
         });
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandomattic",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "bin": "index.js",


### PR DESCRIPTION
Hosts files can contain multiple hosts per line, separated by a space. For example

```
192.168.1.1	automattic.com automattic.wordpress.com
```

This updates the checkbox prompt to show all hosts that might be on a line.